### PR TITLE
Fix invalid default values for vswitch policies for VMM domains

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -541,9 +541,9 @@ module "aci_vmware_vmm_domain" {
   delimiter                   = lookup(each.value, "delimiter", local.defaults.apic.fabric_policies.vmware_vmm_domains.delimiter)
   tag_collection              = lookup(each.value, "tag_collection", local.defaults.apic.fabric_policies.vmware_vmm_domains.tag_collection)
   vlan_pool                   = "${each.value.vlan_pool}${local.defaults.apic.access_policies.vlan_pools.name_suffix}"
-  vswitch_cdp_policy          = lookup(lookup(each.value, "vswitch", {}), "cdp_policy", null)
-  vswitch_lldp_policy         = lookup(lookup(each.value, "vswitch", {}), "lldp_policy", null)
-  vswitch_port_channel_policy = lookup(lookup(each.value, "vswitch", {}), "port_channel_policy", null)
+  vswitch_cdp_policy          = lookup(lookup(each.value, "vswitch", {}), "cdp_policy", "")
+  vswitch_lldp_policy         = lookup(lookup(each.value, "vswitch", {}), "lldp_policy", "")
+  vswitch_port_channel_policy = lookup(lookup(each.value, "vswitch", {}), "port_channel_policy", "")
   credential_policies = [for cp in lookup(each.value, "credential_policies", []) : {
     name     = "${cp.name}${local.defaults.apic.fabric_policies.vmware_vmm_domains.credential_policies.name_suffix}"
     username = cp.username


### PR DESCRIPTION
## Description

This module uses `null` as the default for the following three variables of [netascode/terraform-aci-vmware-vmm-domain](https://github.com/netascode/terraform-aci-vmware-vmm-domain/blob/main/variables.tf) even though `null` is not allowed by it.

* `vswitch_cdp_policy`
* `vswitch_lldp_policy`
* `vswitch_port_channel_policy`

Because of this, if `vswitch` is skipped in `apic > fabric_policies > vmware_vmm_domains` from `./data/xxxx.yaml` like the example below, the plan fails with the error shown below.

### Example (from [Cisco DevNet](https://developer.cisco.com/docs/nexus-as-code/#!vmware-vmm-domain/examples))
```yaml
apic:
  fabric_policies:
    vmware_vmm_domains:
      - name: VMM1
        vlan_pool: VMM1
        credential_policies:
          - name: CRED1
            username: Administrator
            password: C1sco123
        vcenters:
          - name: VC
            hostname_ip: 10.10.10.10
            datacenter: DC1
            credential_policy: CRED1
```

### Error message example
```
│ Error: Invalid value for variable
│
│   on .terraform/modules/fabric_policies/main.tf line 541, in module "aci_vmware_vmm_domain":
│  541:   vswitch_cdp_policy          = lookup(lookup(each.value, "vswitch", {}), "cdp_policy", null)
│     ├────────────────
│     │ var.vswitch_cdp_policy is null
│
│ Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64.
│
│ This was checked by the validation rule at .terraform/modules/fabric_policies.aci_vmware_vmm_domain/variables.tf:54,3-13.
╵
```


## Fix Suggestion
[netascode/terraform-aci-vmware-vmm-domain](https://github.com/netascode/terraform-aci-vmware-vmm-domain/blob/main/variables.tf) sets an empty string ("") as the default for those variables and the validation allows "" as well.
This module should also use an empty string ("") as the default. 
